### PR TITLE
onCallFixePhone numéro appelant

### DIFF
--- a/resources/gcphone/server/server.lua
+++ b/resources/gcphone/server/server.lua
@@ -627,7 +627,14 @@ function onCallFixePhone (source, phone_number, rtcOffer, extraData)
     end
     local sourcePlayer = tonumber(source)
     local srcIdentifier = getPlayerID(source)
-    local srcPhone = getNumberPhone(srcIdentifier)
+
+    local srcPhone = ''
+    if extraData ~= nil and extraData.useNumber ~= nil then
+        srcPhone = extraData.useNumber
+    else
+        srcPhone = getNumberPhone(srcIdentifier)
+    end
+
     AppelsEnCours[indexCall] = {
         id = indexCall,
         transmitter_src = sourcePlayer,


### PR DESCRIPTION
Corrige le numéro appelant lorsque l'appel est effectué depuis une ligne fixe.
_Avant, le numéro affiché était celui du joueur au lieu d'être celui du téléphone fixe._