### PR TITLE
Fixed support for mysql-async v3

### DIFF
--- a/resources/gcphone/server/app_tchat.lua
+++ b/resources/gcphone/server/app_tchat.lua
@@ -5,15 +5,16 @@ function TchatGetMessageChannel (channel, cb)
 end
 
 function TchatAddMessage (channel, message)
-  local Query = "INSERT INTO phone_app_chat (`channel`, `message`) VALUES(@channel, @message);"
-  local Query2 = 'SELECT * from phone_app_chat WHERE `id` = (SELECT LAST_INSERT_ID());'
-  local Parameters = {
+  local id = MySQL.Sync.insert("INSERT INTO phone_app_chat (`channel`, `message`) VALUES (@channel, @message)", {
     ['@channel'] = channel,
     ['@message'] = message
-  }
-  MySQL.Async.fetchAll(Query .. Query2, Parameters, function (reponse)
-    TriggerClientEvent('gcPhone:tchat_receive', -1, reponse[1])
-  end)
+  })
+
+  local result = MySQL.Sync.fetchAll('SELECT * FROM phone_app_chat WHERE `id` = @id', {
+    ['@id'] = id
+  })
+
+  TriggerClientEvent('gcPhone:tchat_receive', -1, result[1])
 end
 
 

--- a/resources/gcphone/server/server.lua
+++ b/resources/gcphone/server/server.lua
@@ -171,16 +171,19 @@ AddEventHandler('gcPhone:_internalAddMessage', function(transmitter, receiver, m
 end)
 
 function _internalAddMessage(transmitter, receiver, message, owner)
-    local Query = "INSERT INTO phone_messages (`transmitter`, `receiver`,`message`, `isRead`,`owner`) VALUES(@transmitter, @receiver, @message, @isRead, @owner);"
-    local Query2 = 'SELECT * from phone_messages WHERE `id` = (SELECT LAST_INSERT_ID());'
-	local Parameters = {
+    local id = MySQL.Sync.insert("INSERT INTO phone_messages (`transmitter`, `receiver`, `message`, `isRead`, `owner`) VALUES (@transmitter, @receiver, @message, @isRead, @owner)", {
         ['@transmitter'] = transmitter,
         ['@receiver'] = receiver,
         ['@message'] = message,
         ['@isRead'] = owner,
         ['@owner'] = owner
-    }
-	return MySQL.Sync.fetchAll(Query .. Query2, Parameters)[1]
+    })
+
+    local result = MySQL.Sync.fetchAll('SELECT * FROM phone_messages WHERE `id` = @id', {
+        ['@id'] = id
+    })
+
+    return result[1]
 end
 
 function addMessage(source, identifier, phone_number, message)


### PR DESCRIPTION
[As Matti explained](https://forum.fivem.net/t/release-mysql-async-library-3-0-8/21881/378) mysql-async v3 doesn't support multiple queries per mysql-async query. This caused an 'whitescreen' when sending a message on gcphone.

This PR fixes the issue by seperating the queries to two mysql-async queries.

I guess the `TchatAddMessage()` function should/could be async but I didn't do that.